### PR TITLE
Changed the prepare command to npm install --force

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -7,7 +7,7 @@ var NODE_RULES = [{
   exists: true,
   language: 'node.js',
   framework: null,
-  prepare: 'npm install',
+  prepare: 'npm install --force',
   test: 'npm test',
   start: 'npm start',
   path: path.join(__dirname, '../node_modules/npm/bin')


### PR DESCRIPTION
Currently the prepare command runs the regular `npm install`. However this doesn't update already installed external dependencies. Therefore tests might succeed even though the latest version of a dependency has some changes which breaks the tests. This can result in exporting broken code. 

This change forces npm to check all dependencies for updates.
