### PR TITLE
node_modules not getting cached

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -122,7 +122,7 @@ module.exports = {
         if (npmInstall) {
           tasks.push(function (next) {
             installPackages(context, context.cachier('modules'), context.dataDir, config.caching, config.update_cache, function (err, exact) {
-              if (err || exact || nocache) return next(err)
+              if (err || exact === true || nocache) return next(err)
               updateCache(context, context.cachier('modules'), context.dataDir, next)
             })
           })


### PR DESCRIPTION
I was having a hard time getting node_modules cached and found that `updateCache` was never getting called from the `installPackages` callback:

```
installPackages(context, context.cachier('modules'), context.dataDir, config.caching, config.update_cache, function (err, exact) {
    if (err || exact || nocache) return next(err)
    updateCache(context, context.cachier('modules'), context.dataDir, next)
})
```

I logged the value of `exact` and found out it to be the output of the `npm install`.  `exact` is set `true` when the `package.json` hashes match

Changing 
`if (err || exact || nocache) return next(err)` 
to 
`if (err || exact === true || nocache) return next(err)` 
fixed it for me.
