### PR TITLE
Update npm and change dependency ranges from tilde to caret #660 

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "async": "^0.2.9",
     "fs-extra": "^0.8.1",
     "n": "^1.1.0",
-    "npm": "^2.1.11",
+    "npm": ">1.4.0 <3.0.0",
     "strider-detection-rules": "0.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "url": "https://github.com/Strider-CD/strider-node"
   },
   "dependencies": {
-    "strider-detection-rules": "0.0.1",
-    "npm": "~1.3.11",
-    "n": "~1.1.0",
     "MD5": "~1.1.0",
     "async": "~0.2.9",
-    "fs-extra": "~0.8.1"
+    "fs-extra": "~0.8.1",
+    "n": "~1.1.0",
+    "npm": "^2.1.11",
+    "strider-detection-rules": "0.0.1"
   },
   "keywords": [
     "strider",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "url": "https://github.com/Strider-CD/strider-node"
   },
   "dependencies": {
-    "MD5": "~1.1.0",
-    "async": "~0.2.9",
-    "fs-extra": "~0.8.1",
-    "n": "~1.1.0",
+    "MD5": "^1.1.0",
+    "async": "^0.2.9",
+    "fs-extra": "^0.8.1",
+    "n": "^1.1.0",
     "npm": "^2.1.11",
     "strider-detection-rules": "0.0.1"
   },
@@ -44,7 +44,7 @@
     }
   },
   "devDependencies": {
-    "jshint": "~2.3.0",
+    "jshint": "^2.3.0",
     "tap-spec": "^2.1.0",
     "tape": "^3.0.3"
   }


### PR DESCRIPTION
Companion pull request 662 to strider, which fixes an issue where the npm version depended on causes problem with registries expecting the authentication method used by npm >1.4.

As suggested npm dep is for range >1.4 <3.0.0

All tests are green, and the project tests correctly on my strider-CD installation which is now using this branch.